### PR TITLE
Replace CRA with Vite

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
     <meta name="keywords" content="extension" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="manifest" href="manifest.json" />
+    <link rel="icon" href="favicon.ico" />
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
@@ -84,5 +84,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "website",
   "version": "0.2.0",
   "private": true,
+  "type": "module",
   "dependencies": {
-    "@emotion/react": "^11.11.3",
-    "@emotion/styled": "^11.11.0",
-    "@mui/icons-material": "^5.15.4",
-    "@mui/material": "^5.15.4",
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.5",
+    "@mui/icons-material": "^5.15.15",
+    "@mui/material": "^5.15.15",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.2",
@@ -16,17 +17,18 @@
     "@types/react-dom": "^18.2.18",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.2",
-    "react-scripts": "^5.0.1",
+    "react-router-dom": "^6.22.3",
     "typescript": "^5.3.3",
-    "web-vitals": "^3.5.1"
+    "vite": "^5.1.6",
+    "web-vitals": "^3.5.2"
   },
   "scripts": {
-    "dev": "react-scripts start",
+    "dev": "vite",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest",
     "lint": "eslint --ext .js,.ts,.jsx,.tsx src",
     "format": "npm run lint --fix & npx prettier --write \"src/**/*.{js,jsx,ts,tsx}\""
   },
@@ -44,6 +46,7 @@
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.18.1",
+    "@vitejs/plugin-react": "^4.2.1",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard-with-typescript": "^43.0.0",
@@ -51,6 +54,7 @@
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
     "gh-pages": "6.1.1",
-    "prettier": "^3.2.2"
+    "prettier": "^3.2.2",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,11 +8,9 @@ import Footer from './components/Footer';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 function App(): ReactElement {
-  // if using custom domain set basename to '/' for custom
-  // if using github's domain set basename to '/<repo-name>'
   return (
     <div className="App">
-      <Router basename={'/'}>
+      <Router basename={import.meta.env.BASE_URL}>
         <Navbar />
         <Routes>
           <Route path="/" element={<Home />} />

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-import 'react-scripts';

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+    // If publishing to GitHub Pages repo (i.e. [username].github.io/[repo]),
+    // set BASE_URL environment variable to '/[repo]' or manually set it here.
+    // Remember to also set the appropriate value for 'pathSegmentsToKeep' in public/404.html.
+    base: process.env.BASE_URL || '/',
+    build: {
+        outDir: 'build',
+        sourcemap: true,
+        emptyOutDir: true,
+        rollupOptions: {
+            // Fix: MUI emits lots of warnings with Vite when sourcemaps are enabled
+            // https://github.com/vitejs/vite/issues/15012
+            onwarn(warning, defaultHandler) {
+                if (warning.code === 'SOURCEMAP_ERROR') {
+                    return;
+                }
+
+                defaultHandler(warning);
+            },
+        }
+    },
+    plugins: [react()]
+});


### PR DESCRIPTION
Motivation: 
* Commit 163c6b9 causes `npm install` to fail, as `react-scripts` requires TypeScript v4, but the project now uses TypeScript v5.
* Create React App/`react-scripts` has been abandoned, and Vite is widely considered to be its modern replacement.

Main changes:
* Add Vite and remove `react-scripts` from dependencies
* Replace all scripts that use Create React App with its Vite equivalent in `package.json`
* Update other React and MUI dependencies, which fixes some issues when building for production with styled MUI components
* Move `index.html` to the root directory (required by Vite)
* The base URL for the React router is now controlled by the `BASE_URL` environment variable
  * The user can either set this environment variable or manually change it in `vite.config.ts`. Otherwise, it defaults to `/`.
  *  i.e. if the user is deploying to deploying to [username].github.com/Website, the user can run `BASE_URL=/Website npm run build`. The `pathSegmentsToKeep` variable in `public/404.html` still has to be changed in this case.

Preview: https://entriphy.github.io/Website